### PR TITLE
Fixed a compilation error caused by similar conversions in StaticArray

### DIFF
--- a/common/include/common/collections.hpp
+++ b/common/include/common/collections.hpp
@@ -10,6 +10,7 @@ namespace lucid
         StaticArray(const uint32_t& Capacity);
 
         T* operator[](const uint32_t& Index) const;
+        T* operator[](const int32_t& Index) const;
         operator T*() const;
         operator void*() const;
 
@@ -48,6 +49,5 @@ namespace lucid
         LinkedListItem<T>* Tail;
     };
 } // namespace lucid
-
 
 #include "common/collections.tpp"

--- a/common/include/common/collections.tpp
+++ b/common/include/common/collections.tpp
@@ -24,6 +24,13 @@ namespace lucid
     }
 
     template <typename T>
+    T* StaticArray<T>::operator[](const int32_t& Index) const
+    {
+        assert(Index < Length);
+        return array + Index;
+    }
+
+    template <typename T>
     void StaticArray<T>::Add(const T& Element)
     {
         assert(Length < Capacity);

--- a/premake5.lua
+++ b/premake5.lua
@@ -54,7 +54,7 @@ project "lucid"
       "misc/src/**.cpp",
       "misc/include/**.hpp",
       "scene/src/**.cpp",
-      "scene/include/*.hpp",
+      "scene/include/**.hpp",
       "resources/src/**.cpp",
       "resources/include/**.hpp"
    }

--- a/premake5.lua
+++ b/premake5.lua
@@ -41,15 +41,22 @@ project "lucid"
 
    files { 
       "libs/stb/stb_init.cpp",
+      "libs/stb/stb_init.hpp",
       "main.cpp", 
-      "devices/src/gpu/**.cpp",
-      "devices/src/gpu/gl/**.cpp",
-      "platform/src/sdl/**.cpp",
+      "devices/src/**.cpp",
+      "devices/include/**.hpp",
+      "devices/include/**.tpp",
       "platform/src/**.cpp",
+      "platform/include/**.hpp",
       "common/src/**.cpp",
+      "common/include/**.hpp",
+      "common/include/**.tpp",
       "misc/src/**.cpp",
+      "misc/include/**.hpp",
       "scene/src/**.cpp",
-      "resources/src/**.cpp"
+      "scene/include/*.hpp",
+      "resources/src/**.cpp",
+      "resources/include/**.hpp"
    }
 
    filter "platforms:Win64"


### PR DESCRIPTION
Fixed a compilation error caused by similar conversions in StaticArray structure (C2666).

Minor premake5.lua file improvements to make header and template files discoverable in solution explorer when using Visual Studio solution generator.